### PR TITLE
Remove concurrency option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ jspm_packages
 
 # Documentation
 doc
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # cp-amqp-worker
-
-[![CircleCI](https://circleci.com/gh/transcovo/cp-amqp-worker.svg?style=svg&circle-token=ad4d2569df66189b49c841eb8177570d6aeec73f)](https://circleci.com/gh/transcovo/cp-amqp-worker)
-[![Coverage Status](https://coveralls.io/repos/github/transcovo/cp-amqp-worker/badge.svg?t=pv91nK)](https://coveralls.io/github/transcovo/cp-amqp-worker)
-
+[![CircleCI](https://circleci.com/gh/transcovo/chpr-worker.svg?style=shield)](https://circleci.com/gh/transcovo/chpr-worker)
+[![codecov](https://codecov.io/gh/transcovo/chpr-worker/branch/master/graph/badge.svg)](https://codecov.io/gh/transcovo/chpr-worker)
 ### Initialization
 ```javascript
     function* handle(msg) { ... };

--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,9 @@ general:
 dependencies:
   pre:
     - sudo service rabbitmq-server start
+    - npm install -g codecov
 test:
   pre:
     - mocha-only-detector-glob 'test/**/*.js'
   post:
-    - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || echo 'Sending coverage failed'
+    - codecov -t $CODECOV_TOKEN || echo 'Sending coverage failed'

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -7,7 +7,6 @@ const DEFAULT_HEARTBEAT = 10;
 const DEFAULT_TASK_TIMEOUT = 30000;
 const DEFAULT_PROCESS_TIMEOUT = 3000;
 const DEFAULT_PREFETCH = 100;
-const DEFAULT_CONCURRENCY = 1;
 
 const configurationSchema = Joi.object({
   handler: Joi.func().required(),
@@ -23,8 +22,7 @@ const optionsSchema = Joi.object({
   heartbeat: Joi.number().positive().default(DEFAULT_HEARTBEAT),
   taskTimeout: Joi.number().positive().default(DEFAULT_TASK_TIMEOUT),
   processExitTimeout: Joi.number().positive().default(DEFAULT_PROCESS_TIMEOUT),
-  channelPrefetch: Joi.number().positive().default(DEFAULT_PREFETCH),
-  processConcurrency: Joi.number().positive().default(DEFAULT_CONCURRENCY)
+  channelPrefetch: Joi.number().positive().default(DEFAULT_PREFETCH)
 });
 
 /**

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -24,7 +24,6 @@ const DEFAULT_EXCHANGE_TYPE = 'topic';
  * @param {function} [options.taskTimeout] to override default task timeout
  * @param {function} [options.processExitTimeout] to override default process exit timeout
  * @param {function} [options.channelPrefetch] to override default channel prefetch value
- * @param {function} [options.processConcurrency] to override default concurrency value
  * @returns {Object} a worker instance with connection, channel, and listen/close functions
  */
 function createWorker(handler, config, options = {}) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@chauffeur-prive/cp-amqp-worker",
+  "name": "chpr-worker",
   "version": "1.0.0",
   "description": "AMQP worker library",
   "main": "index.js",
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/transcovo/cp-amqp-worker.git",
+    "url": "git+https://github.com/transcovo/chpr-worker.git",
     "private": true
   },
   "keywords": [
@@ -58,7 +58,7 @@
   "author": "Transcovo",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/transcovo/cp-amqp-worker/issues"
+    "url": "https://github.com/transcovo/chpr-worker/issues"
   },
-  "homepage": "https://github.com/transcovo/cp-amqp-worker#readme"
+  "homepage": "https://github.com/transcovo/chpr-worker#readme"
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "chpr-metrics": "1.1.0",
     "co": "4.6.0",
     "joi": "10.2.1",
-    "lodash": "4.14.2",
-    "throng": "4.0.0"
+    "lodash": "4.14.2"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
Discussed with today with @GillesRasigade and @Tehem

Given that:

throng is only needed because we are on heroku
as of now, very few processes actually need throng
heroku is not here to stay for years
using throng from outside this library when needed will be trivial
We decided to remove the processConcurrency option instead of implementing it

This will allow to use the library right now, instead of keeping adding tech debt for things we don't really need