### PR TITLE
TECH Fix multiple handlers bound to multiple routing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ chpr-worker allows you to easily create a worker that take tasks from an AMQP qu
 - Handle disconnections from the AMQP server
 - Validating the schema of the message specifying the task
 
+**WARNING**
+
+The `queueName` configuration must be unique for each worker, otherwise messages won't necessarily be routed to the good consumer.
+
+When listening, the lib will create a queue of the form `queueName.routingKey` for each routing key/handler. That is why the queueName config must really be unique, typically of the form `application.workername`. This will generate a unique queue name per routing key, of the form `application.workername.routingkey`.
+
 Example:
 
 ```javascript

--- a/lib/createWorkers.js
+++ b/lib/createWorkers.js
@@ -21,17 +21,15 @@ const DEFAULT_EXCHANGE_TYPE = 'topic';
 /**
  * Create a worker instance based on configuration
  * @param {Array} handlers array of handlers to handle each message
- * @param {function} handlers.handler function to handle each message
+ * @param {function} handlers.handle function to handle each message
+ * @param {function} handlers.validate function to validate each message body
  * @param {String} handlers.routingKey name of the routing key to bind to
  * @param {Object} config configuration for the worker
  * @param {String} config.workerName name for the worker
  * @param {String} config.amqpUrl url to amqp server
  * @param {String} config.exchangeName name of the exchange to use
  * @param {String} config.queueName name of the queue to listen on
- * @param {String} [config.routingKey] name of the routing key to bind to. Required when `handlers`
- *                                     is a function.
  * @param {Object} [options] additional options
- * @param {function} [options.validator] function to validate the message with
  * @param {Number} [options.heartbeat] to override default heartbeat
  * @param {Number} [options.taskTimeout] to override default task timeout
  * @param {Number} [options.processExitTimeout] to override default process exit timeout
@@ -44,8 +42,9 @@ function createWorkers(handlers, config, options = {}) {
   const configuration = Object.assign({}, workerConfig, workerOptions);
   const configWithoutFuncs = _.omit(configuration, ['amqpUrl', 'handlers', 'validator']);
   configWithoutFuncs.routingKeys = _.map(handlers, 'routingKey');
+
   let workerConnection;
-  let workerChannel;
+  const workerChannels = [];
 
   return {
     listen: co.wrap(_listen),
@@ -60,16 +59,11 @@ function createWorkers(handlers, config, options = {}) {
    */
   function* _listen() {
     workerConnection = yield _connectAmqp(configuration);
-    workerChannel = yield _createChannel(workerConnection, configuration);
     logger.info(
       { options: configWithoutFuncs, workerName: configuration.workerName },
       '[worker#listen] worker started'
     );
-    yield configuration.handlers.map(handler => _bindHandler({
-      queueName: configuration.queueName,
-      exchangeName: configuration.exchangeName,
-      handler
-    }));
+    yield configuration.handlers.map(handler => _bindHandler(handler));
   }
 
   /**
@@ -84,7 +78,7 @@ function createWorkers(handlers, config, options = {}) {
       { options: configWithoutFuncs, workerName: configuration.workerName, forceExit },
       '[worker#close] Shutting down'
     );
-    if (workerChannel) yield workerChannel.close();
+    yield workerChannels.map(channel => channel.close());
     if (workerConnection) yield workerConnection.close(forceExit);
     if (forceExit) setTimeout(process.exit, configuration.processExitTimeout);
   }
@@ -92,15 +86,15 @@ function createWorkers(handlers, config, options = {}) {
   /**
    * Create an AMQP message consumer with the given handler
    *
+   * @param {Object} channel The AMQP channel.
    * @param {function} handle the message handler
    * @param {function} validate the message validator
    * @returns {function} The generator function that consumes an AMQP message
    * @private
    */
-  function _getMessageConsumer(handle, validate) {
+  function _getMessageConsumer(channel, handle, validate) {
     return function* _consumeMessage(message) {
       logger.debug({ message }, '[worker#listen] received message');
-      const channel = _getChannel();
 
       const content = _parseMessage(message);
       if (!content) return channel.ack(message);
@@ -229,15 +223,15 @@ function createWorkers(handlers, config, options = {}) {
    * @private
    */
   function* _createChannel(connection,
-    { exchangeName, queueName, routingKey, channelPrefetch, workerName }) {
+    { exchangeName, queueName, channelPrefetch, workerName }) {
     const channel = yield connection.createChannel();
     logger.info(
-      { exchangeName, queueName, routingKey, channelPrefetch, workerName },
+      { exchangeName, queueName, channelPrefetch, workerName },
       '[AMQP] create channel'
     );
     subscribeToChannelEvents(
       channel,
-      { exchangeName, queueName, routingKey, channelPrefetch, workerName }
+      { exchangeName, queueName, channelPrefetch, workerName }
     );
     yield channel.prefetch(channelPrefetch);
     yield channel.assertExchange(exchangeName, DEFAULT_EXCHANGE_TYPE);
@@ -247,27 +241,44 @@ function createWorkers(handlers, config, options = {}) {
 
 /**
  * Bind a message handler on a queue to consume
- * @param   {String} queueName the queue name
- * @param   {String} exchangeName the exchange name
  * @param   {Object} handler the handler content
- * @param   {function} handler.handler the message handler
+ * @param   {function} handler.handle the message handler
+ * @param   {function} handler.validate the message validator
  * @param   {String} handler.routingKey the routingKey to bind to
  * @returns {*} -
  * @private
  */
-  function* _bindHandler({ queueName, exchangeName, handler: { routingKey, handle, validate } }) {
-    yield workerChannel.bindQueue(queueName, exchangeName, routingKey);
-    yield workerChannel.consume(queueName, co.wrap(_getMessageConsumer(handle, validate)));
-  }
+  function* _bindHandler({ routingKey, handle, validate }) {
+    const { exchangeName, queueName, channelPrefetch, workerName } = workerConfig;
+    const formattedQueueName = _getQueueName(queueName, routingKey);
 
-  /**
-   * Get current active channel
-   * @returns {Object} the channel
-   * @private
-   */
-  function _getChannel() {
-    return workerChannel;
+    const workerChannel = yield _createChannel(workerConnection, {
+      exchangeName,
+      queueName: formattedQueueName,
+      channelPrefetch,
+      workerName
+    });
+    workerChannels.push(workerChannel);
+
+    yield workerChannel.bindQueue(formattedQueueName, exchangeName, routingKey);
+    yield workerChannel.consume(
+      formattedQueueName,
+      co.wrap(_getMessageConsumer(workerChannel, handle, validate))
+    );
   }
+}
+
+/**
+ * Returns the formatted queue name.
+ *
+ * It contains the base queue name and the routing key.
+ *
+ * @param       {String} queueName The base queue name.
+ * @param       {String} routingKey The routing key.
+ * @returns     {String} The formatted queue name.
+ */
+function _getQueueName(queueName, routingKey) {
+  return `${queueName}.${routingKey}`;
 }
 
 module.exports = {

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -43,23 +43,22 @@ function subscribeToConnectionEvents(connection, workerName) {
  * @param {Object} channel the channel object
  * @param {String} exchangeName the exchange name to use
  * @param {String} queueName the queue name to target
- * @param {String} routingKey routing key to bind on
  * @param {Number} channelPrefetch number of message to prefetch from channel
  * @param {String} workerName the name of the worker (for logs)
  * @returns {*} -
  * @private
  */
 function subscribeToChannelEvents(channel,
-  { exchangeName, queueName, routingKey, channelPrefetch, workerName }) {
+  { exchangeName, queueName, channelPrefetch, workerName }) {
   channel.on('error', err => {
     logger.error(
-      { err, exchangeName, queueName, routingKey, channelPrefetch, workerName },
+      { err, exchangeName, queueName, channelPrefetch, workerName },
       '[AMQP] channel error'
     );
   });
   channel.on('close', () => {
     logger.info(
-      { exchangeName, queueName, routingKey, channelPrefetch, workerName },
+      { exchangeName, queueName, channelPrefetch, workerName },
       '[AMQP] channel closed'
     );
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-worker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "AMQP worker library",
   "main": "index.js",
   "engines": {

--- a/test/lib/lib.test.js
+++ b/test/lib/lib.test.js
@@ -18,7 +18,6 @@ describe('Lib', () => {
   const workerName = 'test';
   const queueName = 'test.test_watcher';
   const exchangeName = 'testexchange';
-  const routingKey = 'test.something_happened';
   const sandbox = sinon.sandbox.create();
   let connection;
   let channel;
@@ -93,8 +92,7 @@ describe('Lib', () => {
         workerName,
         amqpUrl,
         exchangeName,
-        queueName,
-        routingKey
+        queueName
       });
       channel.emit('close');
       expect(logger.info.calledWithMatch(
@@ -108,8 +106,7 @@ describe('Lib', () => {
         workerName,
         amqpUrl,
         exchangeName,
-        queueName,
-        routingKey
+        queueName
       });
       channel.emit('error');
       expect(logger.error.calledWithMatch(

--- a/test/lib/worker.test.js
+++ b/test/lib/worker.test.js
@@ -16,6 +16,7 @@ describe('Worker library', () => {
   const queueName = 'test.test_watcher';
   const exchangeName = 'testexchange';
   const routingKey = 'test.something_happened';
+  const formattedQueueName = `${queueName}.${routingKey}`;
   const messageContent = { test: 'message' };
   const messageContent2 = { test: 'message2' };
   const sandbox = sinon.sandbox.create();
@@ -25,7 +26,7 @@ describe('Worker library', () => {
   before(function* before() {
     connection = yield amqplib.connect(amqpUrl);
     channel = yield connection.createChannel();
-    yield channel.deleteQueue(queueName);
+    yield channel.deleteQueue(formattedQueueName);
   });
 
   beforeEach(function* beforeEach() {
@@ -37,7 +38,7 @@ describe('Worker library', () => {
   });
 
   after(function* after() {
-    yield channel.deleteQueue(queueName);
+    yield channel.deleteQueue(formattedQueueName);
     yield channel.deleteExchange(exchangeName);
     yield connection.close();
   });
@@ -175,7 +176,7 @@ describe('Worker library', () => {
       expect(workerCalled).to.be.false();
       expect(logger.warn.called).to.be.true();
       yield worker.close(false);
-      const message = yield channel.get(queueName);
+      const message = yield channel.get(formattedQueueName);
       expect(message).to.be.false();
     });
 
@@ -206,7 +207,7 @@ describe('Worker library', () => {
       expect(workerCalled).to.be.false();
       expect(logger.warn.called).to.be.true();
       yield worker.close(false);
-      const message = yield channel.get(queueName);
+      const message = yield channel.get(formattedQueueName);
       expect(message).to.be.false();
     });
 
@@ -233,7 +234,7 @@ describe('Worker library', () => {
       yield cb => setTimeout(cb, 100);
       expect(workerCalled).to.be.true();
       yield worker.close(false);
-      const message = yield channel.get(queueName);
+      const message = yield channel.get(formattedQueueName);
       expect(message).to.be.false();
     });
 
@@ -271,7 +272,7 @@ describe('Worker library', () => {
       expect(worker1CallParameter).to.deep.equal(messageContent2);
       expect(worker2CallParameter).to.deep.equal({ validated: true });
       yield worker.close(false);
-      const message = yield channel.get(queueName);
+      const message = yield channel.get(formattedQueueName);
       expect(message).to.be.false();
     });
 
@@ -295,7 +296,7 @@ describe('Worker library', () => {
       yield cb => setTimeout(cb, 100);
       expect(workerCalled).to.be.true();
       yield worker.close(false);
-      const message = yield channel.get(queueName);
+      const message = yield channel.get(formattedQueueName);
       expect(message).to.be.false();
     });
 
@@ -340,7 +341,7 @@ describe('Worker library', () => {
         { workerName },
         '[worker#listen] Message handler failed to process message #1 - retrying one time')
       ).to.be.true();
-      const message = yield channel.get(queueName);
+      const message = yield channel.get(formattedQueueName);
       expect(message).to.be.false();
     });
 
@@ -371,7 +372,7 @@ describe('Worker library', () => {
         { workerName },
         '[worker#listen] Consumer handler failed to process message #2 - discard message and fail')
       ).to.be.true();
-      const message = yield channel.get(queueName);
+      const message = yield channel.get(formattedQueueName);
       expect(message).to.be.false();
     });
   });


### PR DESCRIPTION
We now declare a queue per handler, and bind each of these queues to the
single associated routing key.

### Jira issue

https://transcovo.atlassian.net/browse/TRAN-

### Purpose of this PR

...

### Configuration change

...

### Checks

- [ ] Documentation of environment variables is very clear, even for a newcomer
- [ ] All relevant usecases of are tested
- [ ] These changes won't cause memory / CPU problems even if business grows by a factor of 100
- [ ] It's ok if these changes go to production and then are rolled-back


### Linked PRs:

- ...
