### PR TITLE
TRAN-17494 Bump stakhanov for graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Example:
     }, {
       channelPrefetch: 50,
       taskTimeout: 30000,
-      processExitTimeout: 3000
+      processExitTimeout: 3000,
+      channelCloseTimeout: 500
     });
 ```
 ### Basic use
@@ -66,6 +67,10 @@ add the following parameter to the close function:
 ```javascript
     worker.close(false);
 ```
+
+By default, the `close` method will be called on SIGTERM/SIGINT signals and operate a graceful shutdown.
+If you want to override this behaviour (not recommended for production workers),
+you should specify `closeOnSignals: false` as an option.
 
 ### Events
 

--- a/lib/createWorkers.js
+++ b/lib/createWorkers.js
@@ -3,6 +3,11 @@
 const stakhanov = require('stakhanov');
 const logger = require('chpr-logger');
 
+const OVERRIDEN_DEFAULTS = Object.freeze({
+  channelCloseTimeout: 500,
+  closeOnSignals: true
+});
+
 /**
  * Create a worker instance based on configuration
  * @param {Array} handlers array of handlers to handle each message
@@ -18,11 +23,13 @@ const logger = require('chpr-logger');
  * @param {Number} [options.heartbeat] to override default heartbeat
  * @param {Number} [options.taskTimeout] to override default task timeout
  * @param {Number} [options.processExitTimeout] to override default process exit timeout
+ * @param {Number} [options.channelCloseTimeout=500] to override default channel prefetch value
+ * @param {Boolean} [options.closeOnSignals=true] listen on SIGINT/SIGTERM and close
  * @param {Number} [options.channelPrefetch] to override default channel prefetch value
  * @returns {Object} a worker instance with connection, channel, and listen/close functions
  */
 function createWorkers(handlers, config, options = {}) {
-  const optionsWithLogger = Object.assign({}, options, { logger });
+  const optionsWithLogger = Object.assign({}, OVERRIDEN_DEFAULTS, options, { logger });
   return stakhanov.createWorkers(handlers, config, optionsWithLogger);
 }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "chpr-logger": "2.4.1",
     "lodash": "4.14.2",
-    "stakhanov": "0.2.2"
+    "stakhanov": "0.3.0"
   },
   "devDependencies": {
     "chai": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-worker",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "AMQP worker library",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
### Jira issue

https://transcovo.atlassian.net/browse/TRAN-17494

### Purpose of this PR

Make production workers safer by using the latest version of stakhanov package and enable `closeOnSignals` per default (since this package is the CP-opinionated wrapper of stakhanov and we want graceful shutdown to be the norm).

### Configuration change

...

### Checks

- [ ] Documentation of environment variables is very clear, even for a newcomer
- [ ] All relevant usecases of are tested
- [ ] These changes won't cause memory / CPU problems even if business grows by a factor of 100
- [ ] It's ok if these changes go to production and then are rolled-back


### Linked PRs:

- ...
