### PR TITLE
Bump stackhanov to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-worker",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "AMQP worker library",
   "main": "index.js",
   "engines": {
@@ -12,7 +12,7 @@
   "dependencies": {
     "chpr-logger": "2.4.1",
     "lodash": "4.14.2",
-    "stakhanov": "0.3.0"
+    "stakhanov": "0.3.1"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
### Jira issue

https://transcovo.atlassian.net/browse/TRAN-17741

### Purpose of this PR

Bump stackhanov to `0.3.1`.

### Checks

- [ ] Documentation of environment variables is very clear, even for a newcomer
- [ ] All relevant usecases of are tested
- [ ] These changes won't cause memory / CPU problems even if business grows by a factor of 100
- [ ] It's ok if these changes go to production and then are rolled-back
