### PR TITLE
TRAN-2965 - bump(stakhanov): Bumping to 0.7.3 to fix some close issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-worker",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "AMQP worker library",
   "main": "index.js",
   "engines": {
@@ -12,7 +12,7 @@
   "dependencies": {
     "chpr-logger": "2.9.0",
     "lodash": "4.17.11",
-    "stakhanov": "0.7.2"
+    "stakhanov": "0.7.3"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
### Jira issue

https://transcovo.atlassian.net/browse/TRAN-2965

### Purpose of this PR

This PR bumps `stakhanov` to `0.7.3` to fix some issues described in https://github.com/ChauffeurPrive/stakhanov/pull/20

### Linked PRs:

- https://github.com/ChauffeurPrive/stakhanov/pull/20
